### PR TITLE
Correctly map the 'R' key's alt binding to '3' on the US layout

### DIFF
--- a/finqwerty/src/main/res/raw/pocket_us_1.kcm
+++ b/finqwerty/src/main/res/raw/pocket_us_1.kcm
@@ -70,7 +70,7 @@ key R {
 	label:				'R'
 	base:				'r'
 	shift, capslock:		'R'
-	alt:				'('
+	alt:				'3'
 	sym:				'\u007B'
 }
 


### PR DESCRIPTION
I noticed the `R` key's ALT binding was bound to `(` instead of `3` so this fixes that. (The `T` key is already bound to `(` correctly)